### PR TITLE
Change system index to allow for index name, descriptions

### DIFF
--- a/amcat4/__main__.py
+++ b/amcat4/__main__.py
@@ -20,7 +20,7 @@ from pydantic.fields import ModelField
 from amcat4 import index
 from amcat4.config import get_settings, AuthOptions, Settings, validate_settings
 from amcat4.elastic import connect_elastic, get_system_version, ping, upload_documents
-from amcat4.index import GLOBAL_ROLES, _roles_to_elastic, create_index, set_global_role, Role, list_global_users
+from amcat4.index import GLOBAL_ROLES, create_index, set_global_role, Role, list_global_users
 
 SOTU_INDEX = "state_of_the_union"
 
@@ -108,14 +108,12 @@ def migrate_index(_args):
             try:
                 open("roles.csv", "w").write(json.dumps(indices, indent=2))
                 dest = "roles.csv"
-            except:
+            except Exception:
                 print(json.dumps(indices, indent=2))
                 dest = "screen"
             logging.exception("Something went wrong in migrating, and the old system index is probably lost. Sorry!"
                               f"The authorization information is written to {dest}, I hope this can be fixed...")
             sys.exit(1)
-
-
 
 
 def base_env():
@@ -260,7 +258,7 @@ def main():
     p = subparsers.add_parser('create-test-index', help=f'Create the {SOTU_INDEX} test index')
     p.set_defaults(func=create_test_index)
 
-    p = subparsers.add_parser('migrate', help=f'Migrate the system index to the current version')
+    p = subparsers.add_parser('migrate', help='Migrate the system index to the current version')
     p.set_defaults(func=migrate_index)
 
     args = parser.parse_args()

--- a/amcat4/api/auth.py
+++ b/amcat4/api/auth.py
@@ -74,7 +74,7 @@ def check_global_role(user: str, required_role: Role, raise_error=True):
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error on retrieving user {user}: {e}")
     if global_role and global_role >= required_role:
-        return True
+        return global_role
     if raise_error:
         raise HTTPException(status_code=401, detail=f"User {user} does not have global "
                             f"{required_role.name.title()} permissions on this instance")
@@ -89,14 +89,15 @@ def check_role(user: str, required_role: Role, index: str, required_global_role:
     :param required_role: The minimum role of the user on the given index
     :param index: The index to check the role on
     :param required_global_role: If the user has this global role (default: admin), also allow them access
+    :return: the actual role of the user on this index
     """
     # First, check global role (also checks that user exists and deals with 'admin' special user)
     if check_global_role(user, required_global_role, raise_error=False):
-        return True
+        return get_role(index, user)
     # Global role check was false, so now check local role
     actual_role = get_role(index, user)
     if actual_role and actual_role >= required_role:
-        return True
+        return actual_role
     else:
         raise HTTPException(status_code=401, detail=f"User {user} does not have "
                             f"{required_role.name.title()} permissions on index {index}")

--- a/amcat4/api/index.py
+++ b/amcat4/api/index.py
@@ -38,8 +38,10 @@ def index_list(current_user: str = Depends(authenticated_user)):
 class NewIndex(BaseModel):
     """Form to create a new index."""
 
-    name: str
+    id: str
     guest_role: Optional[RoleType]
+    name: Optional[str]
+    description: Optional[str]
 
 
 @app_index.post("/", status_code=status.HTTP_201_CREATED)
@@ -51,21 +53,10 @@ def create_index(new_index: NewIndex, current_user: str = Depends(authenticated_
     """
     guest_role = new_index.guest_role and Role[new_index.guest_role.upper()]
     try:
-        index.create_index(new_index.name, guest_role=guest_role)
+        index.create_index(new_index.id, guest_role=guest_role, name=new_index.name,
+                           description=new_index.description, admin=current_user)
     except ApiError as e:
-        import json
-        print("BODY: ", json.dumps(e.body, indent=2))
-        print("INFO: ", json.dumps(e.body, indent=2))
-        print("MESSAGE: ", json.dumps(e.body, indent=2))
-        print("META: ", json.dumps(e.body, indent=2))
         raise HTTPException(status_code=400, detail=dict(info=f"Error on creating index: {e}", message=e.message, body=e.body))
-        if (e.message == 'resource_already_exists_exception'):
-            raise HTTPException(status_code=400, detail=f"Error on creating index: Index {new_index.name!r} already exists")
-        raise HTTPException(status_code=400, detail=f"Error on creating index: {e}")
-    try:
-        set_role(new_index.name, current_user, Role.ADMIN)
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Error on assigning user to index: {e}")
 
 
 # TODO Yes, this should be linked to the actual roles enum

--- a/amcat4/api/index.py
+++ b/amcat4/api/index.py
@@ -13,10 +13,10 @@ from amcat4 import elastic, index
 from amcat4.api.auth import (authenticated_user, authenticated_writer,
                              check_role)
 from amcat4.api.common import py2dict
-from amcat4.index import (GLOBAL_ROLES, IndexDoesNotExist, Role, get_global_role, get_index,
-                          get_role, list_known_indices, list_users, refresh_system_index)
+from amcat4.index import (IndexDoesNotExist, Role, get_global_role, get_index,
+                          get_role, list_known_indices, list_users)
 from amcat4.index import refresh_index as es_refresh_index
-from amcat4.index import remove_role, set_role
+from amcat4.index import refresh_system_index, remove_role, set_role
 
 app_index = APIRouter(
     prefix="/index",
@@ -98,8 +98,9 @@ def view_index(ix: str, user: str = Depends(authenticated_user)):
     View the index.
     """
     try:
-        check_role(user, Role.METAREADER, ix, required_global_role=Role.WRITER)
+        role = check_role(user, Role.METAREADER, ix, required_global_role=Role.WRITER)
         d = get_index(ix)._asdict()
+        d['user_role'] = role and role.name
         d['guest_role'] = d['guest_role'].name if d.get('guest_role') else None
         return d
     except IndexDoesNotExist:

--- a/amcat4/api/index.py
+++ b/amcat4/api/index.py
@@ -13,7 +13,7 @@ from amcat4 import elastic, index
 from amcat4.api.auth import (authenticated_user, authenticated_writer,
                              check_role)
 from amcat4.api.common import py2dict
-from amcat4.index import (IndexDoesNotExist, Role, get_global_role, get_index,
+from amcat4.index import (Index, IndexDoesNotExist, Role, get_global_role, get_index,
                           get_role, list_known_indices, list_users)
 from amcat4.index import refresh_index as es_refresh_index
 from amcat4.index import refresh_system_index, remove_role, set_role
@@ -32,7 +32,13 @@ def index_list(current_user: str = Depends(authenticated_user)):
 
     Returns a list of dicts containing name, role, and guest attributes
     """
-    return [ix._asdict() for ix in list_known_indices(current_user)]
+    def index_to_dict(ix: Index) -> dict:
+        ix = ix._asdict()
+        ix['guest_role'] = ix['guest_role'] and ix['guest_role'].name
+        del ix['roles']
+        return ix
+
+    return [index_to_dict(ix) for ix in list_known_indices(current_user)]
 
 
 class NewIndex(BaseModel):

--- a/amcat4/api/users.py
+++ b/amcat4/api/users.py
@@ -20,7 +20,7 @@ app_users = APIRouter(
     tags=["users"])
 
 
-ROLE = Literal["ADMIN", "WRITER", "admin", "writer"]
+ROLE = Literal["ADMIN", "WRITER", "READER", "admin", "writer", "reader"]
 
 
 class UserForm(BaseModel):
@@ -47,7 +47,6 @@ def create_user(new_user: UserForm, _=Depends(authenticated_admin)):
 @app_users.get("/users/me")
 def get_current_user(current_user: str = Depends(authenticated_user)):
     """View the current user."""
-    print("!!!", current_user)
     return _get_user(current_user, current_user)
 
 

--- a/amcat4/api/users.py
+++ b/amcat4/api/users.py
@@ -5,6 +5,7 @@ AmCAT4 can use either Basic or Token-based authentication.
 A client can request a token with basic authentication and store that token for future requests.
 """
 from typing import Literal, Optional
+from importlib.metadata import version
 
 from fastapi import APIRouter, HTTPException, status, Response
 from fastapi.params import Depends
@@ -105,4 +106,5 @@ def get_auth_config():
     return {"middlecat_url": get_settings().middlecat_url,
             "resource": get_settings().host,
             "authorization": get_settings().auth,
-            "warnings": [validate_settings()]}
+            "warnings": [validate_settings()],
+            "api_version": version('amcat4')}

--- a/amcat4/api/users.py
+++ b/amcat4/api/users.py
@@ -26,12 +26,12 @@ ROLE = Literal["ADMIN", "WRITER", "READER", "admin", "writer", "reader"]
 class UserForm(BaseModel):
     """Form to create a new global user."""
     email: EmailStr
-    global_role: Optional[ROLE]
+    role: Optional[ROLE]
 
 
 class ChangeUserForm(BaseModel):
     """Form to change a global user."""
-    global_role: Optional[ROLE]
+    role: Optional[ROLE]
 
 
 @app_users.post("/users/", status_code=status.HTTP_201_CREATED)
@@ -39,7 +39,7 @@ def create_user(new_user: UserForm, _=Depends(authenticated_admin)):
     """Create a new user."""
     if get_global_role(new_user.email) is not None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"User {new_user.email} already exists")
-    role = Role[new_user.global_role.upper()] if new_user.global_role else Role.NONE
+    role = Role[new_user.role.upper()] if new_user.role else Role.NONE
     set_global_role(email=new_user.email, role=role)
     return {"email": new_user.email, "global_role": role.value}
 
@@ -67,13 +67,13 @@ def _get_user(email, current_user):
     if email in ("admin", "guest") or global_role is None:
         raise HTTPException(404, detail=f"User {email} unknown")
     else:
-        return {"email": email, "global_role": global_role.name}
+        return {"email": email, "role": global_role.name}
 
 
 @app_users.get("/users", dependencies=[Depends(authenticated_admin)])
 def list_global_users():
     """List all global users"""
-    return [{'email': email, 'global_role': role.name} for (email, role) in index.list_global_users().items()]
+    return [{'email': email, 'role': role.name} for (email, role) in index.list_global_users().items()]
 
 
 @app_users.delete("/users/{email}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
@@ -94,9 +94,9 @@ def modify_user(email: EmailStr, data: ChangeUserForm, _user=Depends(authenticat
     Modify the given user.
     Only admin can change users.
     """
-    role = Role[data.global_role.upper()]
+    role = Role[data.role.upper()]
     set_global_role(email, role)
-    return {"email": email, "global_role": role.name}
+    return {"email": email, "role": role.name}
 
 
 @app_users.get("/config")

--- a/amcat4/api/users.py
+++ b/amcat4/api/users.py
@@ -73,7 +73,7 @@ def _get_user(email, current_user):
 @app_users.get("/users", dependencies=[Depends(authenticated_admin)])
 def list_global_users():
     """List all global users"""
-    return [{'email': email, 'global_role': role.name} for (email, role) in index.list_global_users()]
+    return [{'email': email, 'global_role': role.name} for (email, role) in index.list_global_users().items()]
 
 
 @app_users.delete("/users/{email}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)

--- a/amcat4/api/users.py
+++ b/amcat4/api/users.py
@@ -47,6 +47,7 @@ def create_user(new_user: UserForm, _=Depends(authenticated_admin)):
 @app_users.get("/users/me")
 def get_current_user(current_user: str = Depends(authenticated_user)):
     """View the current user."""
+    print("!!!", current_user)
     return _get_user(current_user, current_user)
 
 

--- a/amcat4/elastic.py
+++ b/amcat4/elastic.py
@@ -70,7 +70,7 @@ def connect_elastic() -> Elasticsearch:
         return Elasticsearch(settings.elastic_host or None)
 
 
-def get_system_version(elastic = None) -> Optional[int]:
+def get_system_version(elastic=None) -> Optional[int]:
     """
     Get the elastic system index version
     """

--- a/amcat4/elastic.py
+++ b/amcat4/elastic.py
@@ -13,9 +13,9 @@ import functools
 import hashlib
 import json
 import logging
-from typing import Mapping, List, Iterable, Tuple, Union, Sequence, Literal
+from typing import Mapping, List, Iterable, Optional, Tuple, Union, Sequence, Literal
 
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
 
 from amcat4.config import get_settings
@@ -57,25 +57,56 @@ def es() -> Elasticsearch:
         raise ValueError(f"Cannot connect to elastic {get_settings().elastic_host!r}: {e}")
 
 
+def connect_elastic() -> Elasticsearch:
+    """
+    Connect to the elastic server using the system settings
+    """
+    settings = get_settings()
+    if settings.elastic_password:
+        return Elasticsearch(settings.elastic_host or None,
+                             basic_auth=("elastic", settings.elastic_password),
+                             verify_certs=settings.elastic_verify_ssl)
+    else:
+        return Elasticsearch(settings.elastic_host or None)
+
+
+def get_system_version(elastic = None) -> Optional[int]:
+    """
+    Get the elastic system index version
+    """
+    # WvA: I don't like this 'circular' import. Should probably reorganize the elastic and index modules
+    from amcat4.index import GLOBAL_ROLES
+    settings = get_settings()
+    if elastic is None:
+        elastic = es()
+    try:
+        r = elastic.get(index=settings.system_index, id=GLOBAL_ROLES, source_includes="version")
+    except NotFoundError:
+        return None
+    return r['_source']['version']
+
+
 def _setup_elastic():
     """
     Check whether we can connect with elastic
     """
+    # WvA: I don't like this 'circular' import. Should probably reorganize the elastic and index modules
+    from amcat4.index import GLOBAL_ROLES
     settings = get_settings()
     logging.debug(f"Connecting with elasticsearch at {settings.elastic_host}, "
-                  "password? {'yes' if settings.elastic_password else 'no'} ")
-    if settings.elastic_password:
-        elastic = Elasticsearch(settings.elastic_host or None,
-                                basic_auth=("elastic", settings.elastic_password),
-                                verify_certs=settings.elastic_verify_ssl)
-    else:
-        elastic = Elasticsearch(settings.elastic_host or None)
+                  f"password? {'yes' if settings.elastic_password else 'no'} ")
+    elastic = connect_elastic()
     if not elastic.ping():
         raise Exception(f"Cannot connect to elasticsearch server {settings.elastic_host}")
-    if not elastic.indices.exists(index=settings.system_index):
+    if elastic.indices.exists(index=settings.system_index):
+        # Check index format version
+        if get_system_version(elastic) is None:
+            raise ValueError(f"System index {settings.elastic_host}::{settings.system_index} is corrupted or uses an "
+                             f"old format. Please repair or migrate before continuing")
+
+    else:
         logging.info(f"Creating amcat4 system index: {settings.system_index}")
         elastic.indices.create(index=settings.system_index, mappings={'properties': SYSTEM_MAPPING})
-        from amcat4.index import GLOBAL_ROLES
         elastic.index(index=settings.system_index, id=GLOBAL_ROLES, document=dict(version=SYSTEM_INDEX_VERSION, roles=[]))
     return elastic
 

--- a/amcat4/elastic.py
+++ b/amcat4/elastic.py
@@ -20,6 +20,8 @@ from elasticsearch.helpers import bulk
 
 from amcat4.config import get_settings
 
+SYSTEM_INDEX_VERSION = 1
+
 ES_MAPPINGS = {
    'long': {"type": "long"},
    'date': {"type": "date", "format": "strict_date_optional_time"},
@@ -41,9 +43,9 @@ DEFAULT_MAPPING = {
 }
 
 SYSTEM_MAPPING = {
-    'index': {"type": "keyword"},
-    'email': {"type": "keyword"},
-    'role': {"type": "keyword"},
+    'name': {"type": "text"},
+    'description': {"type": "text"},
+    'roles': {"type": "nested"},
 }
 
 
@@ -73,6 +75,8 @@ def _setup_elastic():
     if not elastic.indices.exists(index=settings.system_index):
         logging.info(f"Creating amcat4 system index: {settings.system_index}")
         elastic.indices.create(index=settings.system_index, mappings={'properties': SYSTEM_MAPPING})
+        from amcat4.index import GLOBAL_ROLES
+        elastic.index(index=settings.system_index, id=GLOBAL_ROLES, document=dict(version=SYSTEM_INDEX_VERSION, roles=[]))
     return elastic
 
 

--- a/amcat4/index.py
+++ b/amcat4/index.py
@@ -89,7 +89,7 @@ def _index_from_elastic(index):
     return Index(id=index['_id'],
                  name=src.get('name', index['_id']),
                  description=src.get('description'),
-                 guest_role=guest_role and Role[guest_role.upper()],
+                 guest_role=guest_role and guest_role != 'NONE' and Role[guest_role.upper()],
                  roles=_roles_from_elastic(src.get('roles', [])))
 
 

--- a/amcat4/index.py
+++ b/amcat4/index.py
@@ -63,6 +63,13 @@ def refresh_index(index: str):
     es().indices.refresh(index=index)
 
 
+def refresh_system_index():
+    """
+    Refresh the elasticsearch index
+    """
+    es().indices.refresh(index=get_settings().system_index)
+
+
 def list_known_indices(email: str = None) -> Iterable[Index]:
     """
     List all known indices, e.g. indices registered in this amcat4 instance

--- a/amcat4/index.py
+++ b/amcat4/index.py
@@ -24,24 +24,22 @@ Note that these rules are not enforced in this module, they should be enforced b
 
 Elasticsearch implementation
 - There is a system index (configurable name, default: amcat4_system)
-- This system index contains authorization records: {index, email, role} with id f"{index}|{email}"
-- Index _global defines the global roles of a user
-- Email _guest defubes the guest roles of an index
-- (elasticsearch index names cannot start with _ or contain |)
-- Every index should have a guest role defined (possibly None), i.e. the list of guest roles is the list of indices
+- This system index contains a 'document' for each index:
+    {name: "...", description:"...", guest_role: "...", roles: [{email, role}...]}
+- A special _global document defines the global properties for this instance (name, roles)
 """
+import collections
 from enum import IntEnum
-from typing import List, Set, Optional, Iterable, Tuple
+from typing import Dict, Iterable, List, Optional
 
 import elasticsearch.helpers
 from elasticsearch import NotFoundError
 
 from amcat4.config import get_settings
-from amcat4.elastic import es, DEFAULT_MAPPING
+from amcat4.elastic import DEFAULT_MAPPING, es
 
 
 class Role(IntEnum):
-    NONE = 0
     METAREADER = 10
     READER = 20
     WRITER = 30
@@ -51,43 +49,59 @@ class Role(IntEnum):
 GUEST_USER = "_guest"
 GLOBAL_ROLES = "_global"
 
+Index = collections.namedtuple("Index", ["id", "name", "description", "guest_role", "roles"])
+
 
 class IndexDoesNotExist(ValueError):
     pass
 
 
-def list_all_indices(exclude_system_index=True) -> List[str]:
+def refresh_index(index: str):
     """
-    List all indices on the connected elastic cluster.
-    You should probably use the methods in amcat4.index rather than this.
+    Refresh the elasticsearch index
     """
-    result = es().indices.get(index="*")
-    exclude = get_settings().system_index if exclude_system_index else None
-    return [x for x in result.keys() if not (x == exclude)]
+    es().indices.refresh(index=index)
 
 
-def list_known_indices(email: str = None) -> Set[str]:
+def list_known_indices(email: str = None) -> Iterable[Index]:
     """
     List all known indices, e.g. indices registered in this amcat4 instance
     :param email: if given, only list indices visible to this user
     """
-    if email is None or get_global_role(email) == Role.ADMIN or get_settings().auth == "no_auth":
-        query = {"query": {"term": {"email": GUEST_USER}}}
-    else:
-        print(2)
-        # Either user has a role in the index, or index has a non-empty guest role
-        query = {"query": {"bool": {"should": [
-            {"term": {"email": email}},
-            {"bool": {
-                "must": [{"term": {"email": GUEST_USER}}],
-                "must_not": [{"term": {"role": Role.NONE.name}}]}}
-        ]}}}
-    indices = list(elasticsearch.helpers.scan(
-        es(), index=get_settings().system_index, fields=["index"], _source=False, query=query))
-    return {ix['fields']["index"][0] for ix in indices} - {GLOBAL_ROLES}
+    # TODO: Maybe this can be done with a smart query, rather than getting all indices and filtering in python?
+    # I tried the following but had no luck
+    # q_guest = {"bool" : {"filter": {"exists": {"field": "guest_role"}},
+    #                      "must_not": {"term": {"guest_role": {"value": "none", "case_insensitive": True}}}}}
+    # q_role = {"nested": {"path": "roles", "query": {"term": {"roles.email": email}}}}
+    # query = {"bool": {"should": [q_guest, q_role]}}
+    check_role = not (email is None or get_global_role(email) == Role.ADMIN or get_settings().auth == "no_auth")
+    for index in elasticsearch.helpers.scan(es(), index=get_settings().system_index, fields=[], _source=True):
+        ix = _index_from_elastic(index)
+        if ix.name == GLOBAL_ROLES:
+            continue
+        if (not check_role) or (ix.guest_role) or (email in ix.roles):
+            yield ix
 
 
-def create_index(index: str, guest_role: Role = Role.NONE) -> None:
+def _index_from_elastic(index):
+    src = index['_source']
+    guest_role = src.get('guest_role')
+    return Index(id=index['_id'],
+                 name=src.get('name', index['_id']),
+                 description=src.get('description'),
+                 guest_role=guest_role and Role[guest_role.upper()],
+                 roles=_roles_from_elastic(src.get('roles', [])))
+
+
+def get_index(index: str) -> Index:
+    try:
+        index = es().get(index=get_settings().system_index, id=index)
+    except NotFoundError:
+        raise IndexDoesNotExist(index)
+    return _index_from_elastic(index)
+
+
+def create_index(index: str, guest_role: Optional[Role] = None) -> None:
     """
     Create a new index in elasticsearch and register it with this AmCAT instance
     """
@@ -95,23 +109,22 @@ def create_index(index: str, guest_role: Role = Role.NONE) -> None:
     register_index(index, guest_role=guest_role)
 
 
-def register_index(index: str, guest_role: Role = Role.NONE) -> None:
+def register_index(index: str, guest_role: Optional[Role] = None, name: str = None, description: str = None) -> None:
     """
     Register an existing elastic index with this AmCAT instance, i.e. create an entry in the system index
     """
     if not es().indices.exists(index=index):
         raise ValueError(f"Index {index} does not exist")
     system_index = get_settings().system_index
-    if es().exists(index=system_index, id="{name}|_guest"):
+    if es().exists(index=system_index, id=index):
         raise ValueError(f"Index {index} is already registered")
-    _set_auth_entry(index, GUEST_USER, guest_role)
-
-
-def refresh(index: str):
-    """
-    Refresh the elasticsearch index
-    """
-    es().indices.refresh(index=index)
+    es().index(index=system_index,
+               id=index,
+               document=dict(name=(name or index),
+                             roles=[],
+                             description=description,
+                             guest_role=guest_role and guest_role.name))
+    refresh_index(system_index)
 
 
 def delete_index(index: str, ignore_missing=False) -> None:
@@ -131,20 +144,43 @@ def deregister_index(index: str, ignore_missing=False) -> None:
     :param index: The name of the index
     :param ignore_missing: If True, do not throw exception if index does not exist
     """
+    system_index = get_settings().system_index
     try:
-        es().delete_by_query(index=get_settings().system_index, query={"term": {"index": index}})
+        es().delete(index=system_index, id=index)
     except NotFoundError:
         if not ignore_missing:
             raise
     else:
-        refresh(get_settings().system_index)
+        refresh_index(system_index)
 
 
-def set_role(index: str, email: str, role: Role):
+def _roles_from_elastic(roles: List[Dict]) -> Dict[str, Role]:
+    return {role['email']: Role[role['role'].upper()] for role in roles}
+
+
+def _roles_to_elastic(roles: dict) -> List[Dict]:
+    return [{'email': email, 'role': role.name} for (email, role) in roles.items()]
+
+
+def set_role(index: str, email: str, role: Optional[Role]):
     """
     Set the role for this user on the given index)
+    If role is None, remove the role
     """
-    _set_auth_entry(index=index, email=email, role=role)
+    # TODO: It would probably be better to do this with a query script on elastic
+    system_index = get_settings().system_index
+    try:
+        d = es().get(index=system_index, id=index, source_includes="roles")
+    except NotFoundError:
+        raise ValueError(f"Index {index} does is not registered")
+    roles_dict = _roles_from_elastic(d["_source"].get("roles", []))
+    if role:
+        roles_dict[email] = role
+    else:
+        if email not in roles_dict:
+            return  # Nothing to change
+        del roles_dict[email]
+    es().update(index=system_index, id=index, doc=dict(roles=_roles_to_elastic(roles_dict)))
 
 
 def set_global_role(email: str, role: Role):
@@ -154,22 +190,28 @@ def set_global_role(email: str, role: Role):
     set_role(index=GLOBAL_ROLES, email=email, role=role)
 
 
-def set_guest_role(index: str, role: Role):
+def set_guest_role(index: str, guest_role: Optional[Role]):
     """
-    Set the guest role for this index. Set to Role.NONE to disallow guest access
+    Set the guest role for this index. Set to None to disallow guest access
     """
-    set_role(index=index, email=GUEST_USER, role=role)
+    modify_index(index, guest_role=guest_role, remove_guest_role=(guest_role is None))
+
+
+def modify_index(index: str, name: Optional[str] = None, description: Optional[str] = None,
+                 guest_role: Optional[Role] = None, remove_guest_role=False):
+    doc = dict(name=name, description=description, guest_role=guest_role and guest_role.name)
+    doc = {x: v for (x, v) in doc.items() if v}
+    if remove_guest_role:
+        doc['guest_role'] = None
+    if doc:
+        es().update(index=get_settings().system_index, id=index, doc=doc)
 
 
 def remove_role(index: str, email: str):
     """
     Remove the role of this user on the given index
     """
-    if index is None:
-        index = GLOBAL_ROLES
-    system_index = get_settings().system_index
-    es().options(ignore_status=404).delete(index=system_index, id=f"{index}|{email}")
-    es().indices.refresh(index=system_index)
+    set_role(index, email, role=None)
 
 
 def remove_global_role(email: str):
@@ -179,30 +221,24 @@ def remove_global_role(email: str):
     remove_role(index=GLOBAL_ROLES, email=email)
 
 
-def _get_role(index: str, email: str) -> Optional[Role]:
-    """
-    Retrieve the role of this user on this index (or None if no role exists)
-    """
-    try:
-        doc = es().get(index=get_settings().system_index, id=f"{index}|{email}")
-    except NotFoundError:
-        return None
-    role = doc["_source"]["role"]
-    return Role[role.upper()]
-
-
 def get_role(index: str, email: str) -> Optional[Role]:
     """
     Retrieve the role of this user on this index, or the guest role if user has no role
     Raises a ValueError if the index does not exist
     :returns: a Role object, or Role.NONE if the user has no role and no guest role exists
     """
-    role = _get_role(index, email)
-    if role is None:
-        if index == GLOBAL_ROLES:
-            return None
-        return get_guest_role(index)
-    return role
+    try:
+        doc = es().get(index=get_settings().system_index, id=index, source_includes=["roles", "guest_role"])
+    except NotFoundError:
+        raise IndexDoesNotExist(f"Index {index} does not exist or is not registered")
+    roles_dict = _roles_from_elastic(doc['_source'].get('roles', []))
+    if role := roles_dict.get(email):
+        return role
+    if index == GLOBAL_ROLES:
+        return None
+    role = doc['_source'].get('guest_role', None)
+    if role and role.lower() != "none":
+        return Role[role]
 
 
 def get_guest_role(index: str) -> Optional[Role]:
@@ -210,10 +246,13 @@ def get_guest_role(index: str) -> Optional[Role]:
     Return the guest role for this index, raising a IndexDoesNotExist if the index does not exist
     :returns: a Role object, or None if global role was NONE
     """
-    role = _get_role(index=index, email=GUEST_USER)
-    if role is None:
-        raise IndexDoesNotExist(f"Index {index} does not exist")
-    return None if role == Role.NONE else role
+    try:
+        d = es().get(index=get_settings().system_index, id=index, source_includes="guest_role")
+    except NotFoundError:
+        raise IndexDoesNotExist(index)
+    role = d['_source'].get('guest_role')
+    if role and role.lower() != "none":
+        return Role[role]
 
 
 def get_global_role(email: str) -> Optional[Role]:
@@ -228,20 +267,17 @@ def get_global_role(email: str) -> Optional[Role]:
     return get_role(index=GLOBAL_ROLES, email=email)
 
 
-def list_users(index: str) -> Iterable[Tuple[str, Role]]:
+def list_users(index: str) -> Dict[str, Role]:
     """"
     List all users and their roles on the given index
-    :param index: The index to list roles for. If None, list global roles
+    :param index: The index to list roles for.
     :returns: an iterable of (user, Role) pairs
     """
-    r = es().search(index=get_settings().system_index, query={"term": {"index": index}})
-    for doc in r['hits']['hits']:
-        email = doc['_source']['email']
-        if email != GUEST_USER:
-            yield email, Role[doc['_source']['role'].upper()]
+    r = es().get(index=get_settings().system_index, id=index, source_includes='roles')
+    return _roles_from_elastic(r['_source'].get('roles', []))
 
 
-def list_global_users() -> Iterable[Tuple[str, Role]]:
+def list_global_users() -> Dict[str, Role]:
     """"
     List all global users and their roles
     :returns: an iterable of (user, Role) pairs
@@ -249,15 +285,8 @@ def list_global_users() -> Iterable[Tuple[str, Role]]:
     return list_users(index=GLOBAL_ROLES)
 
 
-def _set_auth_entry(index: str, email: str, role: Role):
-    system_index = get_settings().system_index
-    es().index(index=system_index, id=f"{index}|{email}",
-               document=dict(index=index, email=email, role=role.name))
-    refresh(system_index)
-
-
 def delete_user(email: str) -> None:
     """Delete this user from all indices"""
-    system_index = get_settings().system_index
-    es().delete_by_query(index=system_index, query={"term": {"email": email}})
-    refresh(system_index)
+    set_global_role(email, None)
+    for ix in list_known_indices(email):
+        set_role(ix.id, email, None)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(
     name="amcat4",
-    version="4.0.10",
+    version="4.0.11",
     description="API for AmCAT4 Text Analysis",
     author="Wouter van Atteveldt",
     author_email="wouter@vanatteveldt.com",
@@ -24,7 +24,7 @@ setup(
         "python-dotenv",
         "requests",
         "authlib",
-        "pydantic[email]",
+        "pydantic[email]<=1.10.2",
         "pydantic-settings",
         'uvicorn',
         'requests'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from amcat4 import elastic, api  # noqa: E402
 from amcat4.config import get_settings, AuthOptions
 from amcat4.elastic import es
-from amcat4.index import create_index, delete_index, Role, refresh, delete_user, \
+from amcat4.index import create_index, delete_index, Role, refresh_index, delete_user, \
     remove_global_role, set_global_role
 from tests.middlecat_keypair import PUBLIC_KEY
 
@@ -77,7 +77,7 @@ def writer2():
 def user():
     name = "test_user@amcat.nl"
     delete_user(name)
-    set_global_role(name, Role.NONE)
+    set_global_role(name, Role.READER)
     yield name
     delete_user(name)
 
@@ -131,7 +131,7 @@ def upload(index: str, docs: Iterable[dict], **kwargs):
             if k not in doc:
                 doc[k] = v
     elastic.upload_documents(index, docs, **kwargs)
-    refresh(index)
+    refresh_index(index)
     return ids
 
 

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -26,5 +26,5 @@ def test_error_elastic(client, index, admin):
 
 def test_error_index_create(client, writer, index):
     for name in ("Test", "_test", "test test"):
-        check(client, "/index/", 400, "invalid index name", json=dict(name=name), user=writer)
-    check(client, "/index/", 400, "already exists", json=dict(name=index), user=writer)
+        check(client, "/index/", 400, "invalid index name", json=dict(id=name), user=writer)
+    check(client, "/index/", 400, "already exists", json=dict(id=index), user=writer)

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -4,20 +4,27 @@ from amcat4.elastic import es
 from tests.tools import amcat_settings, build_headers
 
 
-def test_documents_unauthorized(client, index, writer, admin):
-    def check(url, status, message, method="post", user=None, **kargs):
-        headers = build_headers(user=user) if user else {}
-        r = getattr(client, method)(url, headers=headers, **kargs)
-        assert r.status_code == status
-        if not re.search(message, r.text.lower()):
-            raise AssertionError(f"Status {r.status_code} error {repr(r.text)} does not match pattern {repr(message)}")
+def check(client, url, status, message, method="post", user=None, **kargs):
+    headers = build_headers(user=user) if user else {}
+    r = getattr(client, method)(url, headers=headers, **kargs)
+    assert r.status_code == status
+    if not re.search(message, r.text.lower()):
+        raise AssertionError(f"Status {r.status_code} error {repr(r.text)} does not match pattern {repr(message)}")
 
-    check("/index/", 401, "global writer permissions")
-    for name in ("Test", "_test", "test test"):
-        check("/index/", 400, "invalid index name", json=dict(name=name), user=writer)
-    check(f"/index/{index}/", 401, f"permissions on index {index}", method='get')
 
+def test_documents_unauthorized(client, index, writer, ):
+    check(client, "/index/", 401, "global writer permissions")
+    check(client, f"/index/{index}/", 401, f"permissions on index {index}", method='get')
+
+
+def test_error_elastic(client, index, admin):
     for hostname in ("doesnotexist.example.com", "https://doesnotexist.example.com:9200"):
         with amcat_settings(elastic_host=hostname):
             es.cache_clear()
-            check(f"/index/{index}/", 500, f"cannot connect.*{hostname}", method='get', user=admin)
+            check(client, f"/index/{index}/", 500, f"cannot connect.*{hostname}", method='get', user=admin)
+
+
+def test_error_index_create(client, writer, index):
+    for name in ("Test", "_test", "test test"):
+        check(client, "/index/", 400, "invalid index name", json=dict(name=name), user=writer)
+    check(client, "/index/", 400, "already exists", json=dict(name=index), user=writer)

--- a/tests/test_api_index.py
+++ b/tests/test_api_index.py
@@ -16,7 +16,7 @@ def test_create_list_delete_index(client, index_name, user, writer, writer2, adm
     check(client.get(f"/index/{index_name}", headers=build_headers(user=writer)), 404)
 
     # Writers can create indices
-    post_json(client, "/index/", user=writer, json=dict(name=index_name))
+    post_json(client, "/index/", user=writer, json=dict(id=index_name))
     refresh()
     assert index_name in {x['name'] for x in get_json(client, "/index/", user=writer)}
 
@@ -28,6 +28,7 @@ def test_create_list_delete_index(client, index_name, user, writer, writer2, adm
 
     # Users can only see indices that they have a role in or that have a guest role
     assert index_name not in {x['name'] for x in get_json(client, "/index/", user=user)}
+    assert index_name not in {x['name'] for x in get_json(client, "/index/", user=writer2)}
     assert index_name in {x['name'] for x in get_json(client, "/index/", user=writer)}
 
     # (Only) index admin can change index guest role
@@ -122,7 +123,7 @@ def test_set_get_delete_roles(client: TestClient, admin: str, writer: str, user:
     assert get_json(client, f"/index/{index}/users", user=admin) == []
 
 
-def test_name_description(client, index, user, admin):
+def test_name_description(client, index, index_name, user, admin):
     # unauthenticated or unauthorized users cannot modify or view an index
     check(client.put(f"/index/{index}", json=dict(name="test")), 401)
     check(client.get(f"/index/{index}"), 401)
@@ -142,9 +143,14 @@ def test_name_description(client, index, user, admin):
     set_role(index, user, None)
     check(client.get(f"/index/{index}", headers=build_headers(user)), 401)
     set_guest_role(index, Role.METAREADER)
-    refresh()
     assert get_json(client, f"/index/{index}", user=user)['name'] == 'test'
 
+    check(client.post("/index", json=dict(id=index_name, description="test2", guest_role="metareader"),
+                      headers=build_headers(admin)), 201)
+    assert get_json(client, f"/index/{index_name}", user=user)['description'] == 'test2'
+
     # name and description should be present in list of indices
+    refresh()
     indices = {ix['id']: ix for ix in get_json(client, "/index")}
     assert indices[index]['description'] == 'ooktest'
+    assert indices[index_name]['description'] == 'test2'

--- a/tests/test_api_index.py
+++ b/tests/test_api_index.py
@@ -1,8 +1,8 @@
 from starlette.testclient import TestClient
 
 from amcat4 import elastic
-from amcat4.index import get_guest_role, Role, set_role, remove_role
-from tests.tools import build_headers, post_json, get_json, check
+from amcat4.index import get_guest_role, Role, set_guest_role, set_role, remove_role
+from tests.tools import build_headers, post_json, get_json, check, refresh
 
 
 def test_create_list_delete_index(client, index_name, user, writer, writer2, admin):
@@ -17,7 +17,8 @@ def test_create_list_delete_index(client, index_name, user, writer, writer2, adm
 
     # Writers can create indices
     post_json(client, "/index/", user=writer, json=dict(name=index_name))
-    assert get_json(client, f"/index/{index_name}", user=writer) == {"index": index_name, "guest_role": "NONE"}
+    refresh()
+    assert index_name in {x['name'] for x in get_json(client, "/index/", user=writer)}
 
     # Users can GET their own index, global writer can GET all indices, others cannot GET non-public indices
     check(client.get(f"/index/{index_name}"), 401)
@@ -119,3 +120,31 @@ def test_set_get_delete_roles(client: TestClient, admin: str, writer: str, user:
     # Global admin can delete anyone
     check(client.delete(writer_url, headers=build_headers(admin)), 200)
     assert get_json(client, f"/index/{index}/users", user=admin) == []
+
+
+def test_name_description(client, index, user, admin):
+    # unauthenticated or unauthorized users cannot modify or view an index
+    check(client.put(f"/index/{index}", json=dict(name="test")), 401)
+    check(client.get(f"/index/{index}"), 401)
+    check(client.put(f"/index/{index}", json=dict(name="test"), headers=build_headers(user)), 401)
+    check(client.get(f"/index/{index}", headers=build_headers(user)), 401)
+
+    # global admin and index writer can change details
+    check(client.put(f"/index/{index}", json=dict(name="test"), headers=build_headers(admin)), 200)
+    set_role(index, user, Role.ADMIN)
+    check(client.put(f"/index/{index}", json=dict(description="ooktest"), headers=build_headers(user)), 200)
+
+    # global admin and index or guest metareader can read details
+    assert get_json(client, f"/index/{index}", user=admin)['description'] == 'ooktest'
+    assert get_json(client, f"/index/{index}", user=user)['name'] == 'test'
+    set_role(index, user, Role.METAREADER)
+    assert get_json(client, f"/index/{index}", user=user)['name'] == 'test'
+    set_role(index, user, None)
+    check(client.get(f"/index/{index}", headers=build_headers(user)), 401)
+    set_guest_role(index, Role.METAREADER)
+    refresh()
+    assert get_json(client, f"/index/{index}", user=user)['name'] == 'test'
+
+    # name and description should be present in list of indices
+    indices = {ix['id']: ix for ix in get_json(client, "/index")}
+    assert indices[index]['description'] == 'ooktest'

--- a/tests/test_api_query.py
+++ b/tests/test_api_query.py
@@ -1,4 +1,4 @@
-from amcat4.index import refresh
+from amcat4.index import refresh_index
 from amcat4.query import query_documents
 from tests.conftest import upload
 from tests.tools import get_json, post_json, dictset
@@ -124,13 +124,13 @@ def test_query_tags(client, index_docs, user):
     assert tags() == {}
     post_json(client, f"/index/{index_docs}/tags_update", user=user, expected=204,
               json=dict(action="add", field="tag", tag="x", filters={'cat': 'a'}))
-    refresh(index_docs)
+    refresh_index(index_docs)
     assert tags() == {'0': ['x'], '1': ['x'], '2': ['x']}
     post_json(client, f"/index/{index_docs}/tags_update", user=user, expected=204,
               json=dict(action="remove", field="tag", tag="x", queries=["text"]))
-    refresh(index_docs)
+    refresh_index(index_docs)
     assert tags() == {'2': ['x']}
     post_json(client, f"/index/{index_docs}/tags_update", user=user, expected=204,
               json=dict(action="add", field="tag", tag="y", ids=["1", "2"]))
-    refresh(index_docs)
+    refresh_index(index_docs)
     assert tags() == {'1': ['y'], '2': ['x', 'y']}

--- a/tests/test_api_user.py
+++ b/tests/test_api_user.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 from amcat4.config import AuthOptions
 from amcat4.index import delete_user, get_global_role, set_guest_role, Role
-from tests.tools import get_json, build_headers, post_json, check, set_auth
+from tests.tools import get_json, build_headers, post_json, check, refresh, set_auth
 
 
 def test_auth(client: TestClient, user, admin, index):
@@ -15,18 +15,21 @@ def test_auth(client: TestClient, user, admin, index):
         # Allow guests - unauthenticated user can access projects with guest roles
         assert client.get(f"/index/{index}").status_code == 401
         set_guest_role(index, Role.READER)
+        refresh()
         assert client.get(f"/index/{index}").status_code == 200
         assert client.get(f"/index/{index}", headers=build_headers(admin)).status_code == 200
     with set_auth(AuthOptions.allow_authenticated_guests):
         # Only use guest roles if user is authenticated
         assert client.get(f"/index/{index}").status_code == 401
         assert client.get(f"/index/{index}", headers=build_headers(unknown_user)).status_code == 200
-        set_guest_role(index, Role.NONE)
+        set_guest_role(index, None)
+        refresh()
         assert client.get(f"/index/{index}", headers=build_headers(unknown_user)).status_code == 401
         assert client.get(f"/index/{index}", headers=build_headers(admin)).status_code == 200
     with set_auth(AuthOptions.authorized_users_only):
         # Only users with a index-level role can access other indices (even as guest)
         set_guest_role(index, Role.READER)
+        refresh()
         assert client.get(f"/index/{index}").status_code == 401
         assert client.get(f"/index/{index}", headers=build_headers(unknown_user)).status_code == 401
         assert client.get(f"/index/{index}", headers=build_headers(user)).status_code == 200
@@ -37,10 +40,10 @@ def test_get_user(client: TestClient, writer, user):
     # Guests have no /me
     assert client.get("/users/me").status_code == 404
     # user can only see its own info:
-    assert get_json(client, "/users/me", user=user) == {"email": user, "global_role": "NONE"}
-    assert get_json(client, f"/users/{user}", user=user) == {"email": user, "global_role": "NONE"}
+    assert get_json(client, "/users/me", user=user) == {"email": user, "global_role": "READER"}
+    assert get_json(client, f"/users/{user}", user=user) == {"email": user, "global_role": "READER"}
     # writer can see everyone
-    assert get_json(client, f"/users/{user}", user=writer) == {"email": user, "global_role": "NONE"}
+    assert get_json(client, f"/users/{user}", user=writer) == {"email": user, "global_role": "READER"}
     assert get_json(client, f"/users/{writer}", user=writer) == {"email": writer, "global_role": 'WRITER'}
     # Retrieving a non-existing user as admin should give 404
     delete_user(user)
@@ -79,4 +82,4 @@ def test_list_users(client: TestClient, index, admin, user):
     check(client.get("/users", headers=build_headers(user)), 401)
     result = get_json(client, "/users", user=admin)
     assert {'email': admin, 'global_role': 'ADMIN'} in result
-    assert {'email': user, 'global_role': 'NONE'} in result
+    assert {'email': user, 'global_role': 'READER'} in result

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from amcat4 import elastic
 from amcat4.elastic import get_fields
-from amcat4.index import refresh
+from amcat4.index import refresh_index
 from amcat4.query import query_documents
 from tests.conftest import upload
 
@@ -60,24 +60,24 @@ def test_add_tag(index_docs):
 
     assert tags() == {}
     elastic.update_tag_by_query(index_docs, "add",  q('0', '1'), "tag", "x")
-    refresh(index_docs)
+    refresh_index(index_docs)
     assert tags() == {'0': ['x'], '1': ['x']}
     elastic.update_tag_by_query(index_docs, "add", q('1', '2'), "tag", "x")
-    refresh(index_docs)
+    refresh_index(index_docs)
     assert tags() == {'0': ['x'], '1': ['x'], '2': ['x']}
     elastic.update_tag_by_query(index_docs, "add", q('2', '3'), "tag", "y")
-    refresh(index_docs)
+    refresh_index(index_docs)
     assert tags() == {'0': ['x'], '1': ['x'], '2': ['x', 'y'], '3': ['y']}
     elastic.update_tag_by_query(index_docs, "remove", q('0', '2', '3'), "tag", "x")
-    refresh(index_docs)
+    refresh_index(index_docs)
     assert tags() == {'1': ['x'], '2': ['y'], '3': ['y']}
 
 
 def test_deduplication(index):
     doc = {"title": "titel", "text": "text", "date": datetime(2020, 1, 1)}
     elastic.upload_documents(index, [doc])
-    refresh(index)
+    refresh_index(index)
     assert query_documents(index).total_count == 1
     elastic.upload_documents(index, [doc])
-    refresh(index)
+    refresh_index(index)
     assert query_documents(index).total_count == 1

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,60 +1,92 @@
+from typing import List
+
 import pytest
 
 from amcat4.config import get_settings
 from amcat4.elastic import es
-from amcat4.index import create_index, list_all_indices, list_known_indices, delete_index, register_index, \
-    deregister_index, get_role, set_role, remove_role, Role, get_global_role, remove_global_role, set_global_role
+from amcat4.index import (Role, create_index, delete_index, deregister_index,
+                          get_global_role, get_guest_role, get_index, get_role,
+                          list_global_users, list_known_indices, list_users,
+                          modify_index, refresh_index, register_index,
+                          remove_global_role, remove_role, set_global_role,
+                          set_guest_role, set_role)
+from tests.tools import refresh
+
+
+def list_es_indices() -> List[str]:
+    """
+    List all indices on the connected elastic cluster.
+    """
+    return list(es().indices.get(index="*").keys())
+
+
+def list_index_names(email: str = None) -> List[str]:
+    return [ix.name for ix in list_known_indices(email)]
 
 
 def test_create_delete_index():
     # Can we create and delete indices?
     index = "amcat4_unittest"
     delete_index(index, ignore_missing=True)
-    assert index not in list_all_indices()
-    assert index not in list_known_indices()
+    refresh_index(get_settings().system_index)
+    assert index not in list_es_indices()
+    assert index not in list_index_names()
     create_index(index)
-    assert index in list_all_indices()
-    assert index in list_known_indices()
+    refresh_index(get_settings().system_index)
+    assert index in list_es_indices()
+    assert index in list_index_names()
     # Cannot create or register duplicate index
     with pytest.raises(Exception):
         create_index(index.name)
     with pytest.raises(Exception):
         register_index(index.name)
     delete_index(index)
-    assert index not in list_all_indices()
-    assert index not in list_known_indices()
+    refresh_index(get_settings().system_index)
+    assert index not in list_es_indices()
+    assert index not in list_index_names()
 
 
 def test_register_index():
     index = "amcat4_unittest"
     delete_index(index, ignore_missing=True)
     es().indices.create(index=index)
-    assert index in list_all_indices()
-    assert index not in list_known_indices()
+    assert index in list_es_indices()
+    assert index not in list_index_names()
     register_index(index)
-    assert index in list_known_indices()
+    refresh_index(get_settings().system_index)
+    assert index in list_index_names()
     deregister_index(index)
-    assert index not in list_known_indices()
+    refresh_index(get_settings().system_index)
+    assert index not in list_index_names()
 
 
 def test_list_indices(index, guest_index, admin):
-    assert index in list_known_indices()
-    assert guest_index in list_known_indices()
-    assert index in list_known_indices(admin)
-    assert guest_index in list_known_indices(admin)
+    assert index in list_index_names()
+    assert guest_index in list_index_names()
+    assert index in list_index_names(admin)
+    assert guest_index in list_index_names(admin)
     user = "user@example.com"
-    assert index not in list_known_indices(user)
-    assert guest_index in list_known_indices(user)
+    assert index not in list_index_names(user)
+    assert guest_index in list_index_names(user)
+    set_role(index, user, Role.WRITER)
+    refresh_index(get_settings().system_index)
+    assert index in list_index_names(user)
+    remove_role(index, user)
+    refresh_index(get_settings().system_index)
+    assert index not in list_index_names(user)
 
 
 def test_global_roles():
     user = "user@example.com"
     assert get_global_role(user) is None
     set_global_role(user, Role.ADMIN)
+    refresh_index(get_settings().system_index)
     assert get_global_role(user) == Role.ADMIN
     set_global_role(user, Role.WRITER)
+    refresh_index(get_settings().system_index)
     assert get_global_role(user) == Role.WRITER
     remove_global_role(user)
+    refresh_index(get_settings().system_index)
     assert get_global_role(user) is None
 
 
@@ -62,15 +94,50 @@ def test_index_roles(index):
     user = "user@example.com"
     assert get_role(index, user) is None
     set_role(index, user, Role.METAREADER)
+    refresh_index(get_settings().system_index)
     assert get_role(index, user) == Role.METAREADER
     set_role(index, user, Role.ADMIN)
+    refresh_index(get_settings().system_index)
     assert get_role(index, user) == Role.ADMIN
     remove_role(index, user)
+    refresh_index(get_settings().system_index)
     assert get_role(index, user) is None
+
+
+def test_guest_role(index):
+    assert get_guest_role(index) is None
+    set_guest_role(index, Role.READER)
+    refresh()
+    assert get_guest_role(index) == Role.READER
 
 
 def test_builtin_admin(index):
     user = "admin@example.com"
     get_settings().admin_email = user
     assert get_global_role(user) == Role.ADMIN
-    assert index in list_known_indices(user)
+    assert index in list_index_names(user)
+
+
+def test_list_users(index, user):
+    set_global_role(user, role=Role.WRITER)
+    refresh_index(get_settings().system_index)
+    assert list_global_users()[user] == Role.WRITER
+    remove_global_role(user)
+    refresh_index(get_settings().system_index)
+    assert user not in list_global_users()
+
+    set_role(index=index, email=user, role=Role.ADMIN)
+    refresh_index(get_settings().system_index)
+    assert list_users(index)[user] == Role.ADMIN
+    remove_role(index=index, email=user)
+    refresh_index(get_settings().system_index)
+    assert user not in list_users(index)
+
+
+def test_name_description(index):
+    modify_index(index, name="test", description="ooktest")
+    refresh()
+    assert get_index(index).name == "test"
+    assert get_index(index).description == "ooktest"
+    indices = {x.id: x for x in list_known_indices()}
+    assert indices[index].name == "test"

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -8,6 +8,7 @@ from authlib.jose import jwt
 from fastapi.testclient import TestClient
 
 from amcat4.config import AuthOptions, get_settings
+from amcat4.index import refresh_index
 from tests.middlecat_keypair import PRIVATE_KEY
 
 
@@ -77,10 +78,12 @@ def amcat_settings(**kargs):
     old_settings = settings.dict()
     try:
         for k, v in kargs.items():
-            print(k, v)
             setattr(settings, k, v)
         yield settings
     finally:
         for k, v in old_settings.items():
-            print(k, v)
             setattr(settings, k, v)
+
+
+def refresh():
+    refresh_index(get_settings().system_index)


### PR DESCRIPTION
I changed the system_index from a list of auth entries to a more flexible format where each index is a {name, roles, ...} object. This allows for indices to have names, descriptions etc, but could also be used to add e.g. tags or even codebooks in the future. 

The unit tests pass but I haven't tried using it in a client. In any case, this would require a change in existing installations. I've added a check on startup and migrate action in `__main__`, but it's not exceedingly well tested. 